### PR TITLE
fix: correct CLI command from 'openclaw setup' to 'openclaw onboard'

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 openclaw plugins install @seeed-studio/meshtastic
 
 # 2. Guided setup — walks you through transport, region, and access policy
-openclaw setup
+openclaw onboard
 
 # 3. Verify
 openclaw channels status --probe
@@ -101,7 +101,7 @@ Fallback: [media/demo.mp4](media/demo.mp4)
 
 ## Setup Wizard
 
-Running `openclaw setup` launches an interactive wizard that walks you through each configuration step. Below is what each step means and how to choose.
+Running `openclaw onboard` launches an interactive wizard that walks you through each configuration step. Below is what each step means and how to choose.
 
 ### 1. Transport
 
@@ -178,7 +178,7 @@ Assigns human-readable display names to your accounts. For example, an account w
 
 ## Configuration
 
-The guided setup (`openclaw setup`) covers everything below. See [Setup Wizard](#setup-wizard) for a step-by-step walkthrough. For manual config, edit with `openclaw config edit`.
+The guided setup (`openclaw onboard`) covers everything below. See [Setup Wizard](#setup-wizard) for a step-by-step walkthrough. For manual config, edit with `openclaw config edit`.
 
 ### Serial (USB)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,7 +36,7 @@
 openclaw plugins install @seeed-studio/meshtastic
 
 # 2. 交互式设置 — 引导完成传输方式、频率区域、访问策略等配置
-openclaw setup
+openclaw onboard
 
 # 3. 验证
 openclaw channels status --probe
@@ -101,7 +101,7 @@ https://github.com/user-attachments/assets/a3e46e9d-cf5a-4743-9830-f671a1998ca0
 
 ## 设置向导
 
-运行 `openclaw setup` 会启动一个交互式向导，逐步引导你完成配置。以下是每一步的含义和选择建议。
+运行 `openclaw onboard` 会启动一个交互式向导，逐步引导你完成配置。以下是每一步的含义和选择建议。
 
 ### 1. 传输方式（Transport）
 
@@ -178,7 +178,7 @@ https://github.com/user-attachments/assets/a3e46e9d-cf5a-4743-9830-f671a1998ca0
 
 ## 配置
 
-交互式设置（`openclaw setup`）涵盖以下所有内容。详细步骤说明参见[设置向导](#设置向导)。如需手动编辑，使用 `openclaw config edit`。
+交互式设置（`openclaw onboard`）涵盖以下所有内容。详细步骤说明参见[设置向导](#设置向导)。如需手动编辑，使用 `openclaw config edit`。
 
 ### Serial（USB 串口）
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -294,7 +294,7 @@ export const meshtasticPlugin: ChannelPlugin<ResolvedMeshtasticAccount, Meshtast
       if (!account.configured) {
         return {
           ok: false,
-          error: "Not configured. Run 'openclaw setup' to configure.",
+          error: "Not configured. Run 'openclaw onboard' to configure.",
           transport: account.transport,
         } as MeshtasticProbe;
       }
@@ -377,7 +377,7 @@ export const meshtasticPlugin: ChannelPlugin<ResolvedMeshtasticAccount, Meshtast
       if (!account.configured) {
         throw new Error(
           `Meshtastic is not configured for account "${account.accountId}". ` +
-            `Run 'openclaw setup' or set channels.meshtastic.transport and connection details in config.`,
+            `Run 'openclaw onboard' or set channels.meshtastic.transport and connection details in config.`,
         );
       }
       const transportDesc =

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -59,7 +59,7 @@ export async function monitorMeshtasticProvider(
   if (!account.configured) {
     throw new Error(
       `Meshtastic is not configured for account "${account.accountId}". ` +
-        `Run 'openclaw setup' or set channels.meshtastic.transport and connection details in config.`,
+        `Run 'openclaw onboard' or set channels.meshtastic.transport and connection details in config.`,
     );
   }
 
@@ -247,7 +247,7 @@ async function monitorMqtt(params: {
   const mqttConfig = account.config.mqtt;
 
   if (!mqttConfig?.broker) {
-    throw new Error("MQTT broker not configured. Set channels.meshtastic.mqtt.broker or run 'openclaw setup'.");
+    throw new Error("MQTT broker not configured. Set channels.meshtastic.mqtt.broker or run 'openclaw onboard'.");
   }
 
   let mqttClient: MeshtasticMqttClient | null = null;

--- a/src/send.ts
+++ b/src/send.ts
@@ -53,7 +53,7 @@ export async function sendMessageMeshtastic(
   if (!account.configured) {
     throw new Error(
       `Meshtastic is not configured for account "${account.accountId}". ` +
-        `Run 'openclaw setup' or set channels.meshtastic.transport and connection details in config.`,
+        `Run 'openclaw onboard' or set channels.meshtastic.transport and connection details in config.`,
     );
   }
 


### PR DESCRIPTION
## Summary

- The interactive onboarding wizard is `openclaw onboard`, not `openclaw setup` (`setup` only initializes local config/workspace)
- Fixed all 11 occurrences across 5 files:
  - `README.md` (3)
  - `README.zh-CN.md` (3)
  - `src/channel.ts` (2 — error messages)
  - `src/monitor.ts` (2 — error messages)
  - `src/send.ts` (1 — error message)