### PR TITLE
fix: align MQTT JSON transport with the Meshtastic protocol

### DIFF
--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -82,7 +82,6 @@ async function deliverMeshtasticReply(params: {
   target: string;
   accountId: string;
   channelIndex?: number;
-  channelName?: string;
   chunkLimit?: number;
   sendReply?: (target: string, text: string) => Promise<void>;
   statusSink?: (patch: { lastOutboundAt?: number }) => void;
@@ -104,7 +103,6 @@ async function deliverMeshtasticReply(params: {
       await sendMessageMeshtastic(params.target, chunk, {
         accountId: params.accountId,
         channelIndex: params.channelIndex,
-        channelName: params.channelName,
       });
     }
     // Small delay between chunks to avoid overwhelming the radio queue.
@@ -383,7 +381,6 @@ export async function handleMeshtasticInbound(params: {
       target: peerId,
       accountId: account.accountId,
       channelIndex: message.isGroup ? message.channelIndex : undefined,
-      channelName: message.isGroup ? message.channelName : undefined,
       chunkLimit: account.config.textChunkLimit,
       sendReply: params.sendReply,
       statusSink,

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -289,8 +289,11 @@ async function monitorMqtt(params: {
           if (!mqttClient) {
             return;
           }
-          const channelName = message.isGroup ? message.channelName : undefined;
-          await mqttClient.sendText(text, message.isGroup ? undefined : target, channelName);
+          await mqttClient.sendText(
+            text,
+            message.isGroup ? undefined : target,
+            message.isGroup ? message.channelIndex : undefined,
+          );
           opts.statusSink?.({ lastOutboundAt: Date.now() });
           core.channel.activity.record({
             channel: "meshtastic",
@@ -304,8 +307,8 @@ async function monitorMqtt(params: {
   });
 
   // Register active send function for `openclaw message send`.
-  setActiveMqttSend((text, destination, channelName) =>
-    mqttClient ? mqttClient.sendText(text, destination, channelName) : Promise.resolve(),
+  setActiveMqttSend((text, destination, channelIndex) =>
+    mqttClient ? mqttClient.sendText(text, destination, channelIndex) : Promise.resolve(),
   );
 
   logger.info(

--- a/src/mqtt-client.ts
+++ b/src/mqtt-client.ts
@@ -1,15 +1,17 @@
 import mqtt from "mqtt";
-import { nodeNumToHex } from "./normalize.js";
+import { hexToNodeNum, looksLikeMeshtasticNodeId, nodeNumToHex } from "./normalize.js";
 import type { MeshtasticMqttConfig } from "./types.js";
 
-/** Derive a publish topic from a subscribe topic.
- *  Standard pattern: "msh/REGION/NUM/json/#" → "msh/REGION/NUM/json/mqtt".
- *  If the topic has no wildcard suffix, appends "/mqtt" as the publish leaf. */
+/** Derive the JSON downlink topic from a subscribe topic.
+ *  Standard pattern: "msh/REGION/NUM/json/#" → "msh/REGION/NUM/json/mqtt/".
+ *  Meshtastic firmware accepts JSON downlinks on the ".../2/json/mqtt/" topic;
+ *  a channel named "mqtt" (with downlink enabled) must exist on the gateway.
+ *  See https://meshtastic.org/docs/software/integrations/mqtt/ */
 function derivePublishTopic(subscribeTopic: string): string {
   if (subscribeTopic.endsWith("/#")) {
-    return subscribeTopic.slice(0, -2) + "/mqtt";
+    return subscribeTopic.slice(0, -2) + "/mqtt/";
   }
-  return subscribeTopic + "/mqtt";
+  return subscribeTopic + "/mqtt/";
 }
 
 export type MeshtasticMqttTextEvent = {
@@ -32,13 +34,15 @@ export type MeshtasticMqttClientOptions = {
 };
 
 export type MeshtasticMqttClient = {
-  sendText: (text: string, destination?: string, channelName?: string) => Promise<void>;
+  sendText: (text: string, destination?: string, channelIndex?: number) => Promise<void>;
   close: () => void;
 };
 
 /**
- * Meshtastic MQTT JSON message format.
- * Messages on the JSON topic contain: sender, from, type, payload, channel.
+ * Meshtastic MQTT JSON *uplink* message (received from the broker).
+ * Text packets arrive as { type: "text", payload: { text }, from, to, channel,
+ * sender }, where `from` is the originating node and `sender` is the gateway
+ * node that published the packet to MQTT.
  */
 type MqttJsonMessage = {
   sender?: string;
@@ -48,6 +52,19 @@ type MqttJsonMessage = {
   payload?: { text?: string };
   channel?: number;
   channel_name?: string;
+};
+
+/**
+ * Meshtastic MQTT JSON *downlink* message (published to ".../2/json/mqtt/").
+ * `payload` is a plain string and `from` is the numeric node ID of the gateway
+ * that will transmit the message. `channel` (index) and `to` are optional.
+ */
+type MqttJsonDownlink = {
+  from: number;
+  type: "sendtext";
+  payload: string;
+  channel?: number;
+  to?: number;
 };
 
 /** Connect to a Meshtastic mesh via MQTT broker. */
@@ -109,16 +126,18 @@ export async function connectMeshtasticMqtt(
       return;
     }
 
-    // Only handle text messages.
-    if (msg.type !== "sendtext" || !msg.payload?.text) {
+    // Only handle text messages. Received text packets use type "text"
+    // ("sendtext" is the downlink verb and never appears on uplink).
+    if (msg.type !== "text" || !msg.payload?.text) {
       return;
     }
 
-    // Skip own messages.
-    const senderNodeId = msg.sender
-      ? msg.sender.toLowerCase()
-      : msg.from
-        ? nodeNumToHex(msg.from)
+    // Identify the originating node. `from` is the actual author; `sender` is
+    // only the gateway that uploaded the packet to MQTT, so prefer `from`.
+    const senderNodeId = msg.from !== undefined
+      ? nodeNumToHex(msg.from)
+      : msg.sender
+        ? msg.sender.toLowerCase()
         : undefined;
     if (!senderNodeId) {
       return;
@@ -134,13 +153,10 @@ export async function connectMeshtasticMqtt(
       && msg.to !== 0xffffffff
       && nodeNumToHex(msg.to).toLowerCase() === myNodeId;
 
-    const senderName = msg.sender && msg.sender !== senderNodeId
-      ? msg.sender
-      : undefined;
-
+    // The JSON envelope carries no display name (`sender` is the gateway node
+    // ID, not a name), so leave senderName unset and let the node ID stand in.
     const event: MeshtasticMqttTextEvent = {
       senderNodeId: senderNodeId.startsWith("!") ? senderNodeId : `!${senderNodeId}`,
-      senderName,
       text: msg.payload.text,
       channelIndex: msg.channel ?? 0,
       channelName: msg.channel_name,
@@ -166,18 +182,24 @@ export async function connectMeshtasticMqtt(
   }
 
   return {
-    sendText: async (text, destination, channelName) => {
-      const outboundTopic = channelName
-        ? publishTopic.replace(/\/[^/]*$/, `/${channelName}`)
-        : publishTopic;
-      const message: MqttJsonMessage = {
-        sender: myNodeId ?? options.myNodeId,
+    sendText: async (text, destination, channelIndex) => {
+      // Standard Meshtastic JSON downlink: publish to ".../2/json/mqtt/" with
+      // { from, type: "sendtext", payload: <string>, channel?, to? }. `payload`
+      // is a plain string (not an object) and `from` is the numeric node ID of
+      // the gateway that transmits. The gateway needs a channel named "mqtt"
+      // with downlink enabled and JSON output on.
+      // https://meshtastic.org/docs/software/integrations/mqtt/
+      const fromNum = myNodeId ? hexToNodeNum(myNodeId) : 0;
+      const message: MqttJsonDownlink = {
+        from: fromNum,
         type: "sendtext",
-        payload: { text },
-        ...(destination ? { to: Number.parseInt(destination.replace("!", ""), 16) } : {}),
-        ...(channelName ? { channel_name: channelName } : {}),
+        payload: text,
+        ...(channelIndex !== undefined ? { channel: channelIndex } : {}),
+        ...(destination && looksLikeMeshtasticNodeId(destination)
+          ? { to: hexToNodeNum(destination) }
+          : {}),
       };
-      client.publish(outboundTopic, JSON.stringify(message));
+      client.publish(publishTopic, JSON.stringify(message));
     },
     close: () => {
       client.end(true);

--- a/src/send.ts
+++ b/src/send.ts
@@ -23,7 +23,7 @@ let activeSerialSend:
   | ((text: string, destination?: number, channelIndex?: number) => Promise<number>)
   | null = null;
 let activeMqttSend:
-  | ((text: string, destination?: string, channelName?: string) => Promise<void>)
+  | ((text: string, destination?: string, channelIndex?: number) => Promise<void>)
   | null = null;
 
 export function setActiveSerialSend(
@@ -33,7 +33,7 @@ export function setActiveSerialSend(
 }
 
 export function setActiveMqttSend(
-  fn: ((text: string, destination?: string, channelName?: string) => Promise<void>) | null,
+  fn: ((text: string, destination?: string, channelIndex?: number) => Promise<void>) | null,
 ) {
   activeMqttSend = fn;
 }
@@ -79,7 +79,7 @@ export async function sendMessageMeshtastic(
 
   if (transport === "mqtt") {
     if (activeMqttSend) {
-      await activeMqttSend(stripped, target, opts.channelName);
+      await activeMqttSend(stripped, target, opts.channelIndex);
     } else {
       throw new Error("No active MQTT connection. Run 'openclaw gateway start' to connect.");
     }

--- a/src/send.ts
+++ b/src/send.ts
@@ -10,7 +10,6 @@ import type { CoreConfig } from "./types.js";
 type SendMeshtasticOptions = {
   accountId?: string;
   channelIndex?: number;
-  channelName?: string;
 };
 
 export type SendMeshtasticResult = {


### PR DESCRIPTION
## Problem

The `mqtt` transport documents the standard Meshtastic broker as its default
(`mqtt.meshtastic.org`, `meshdev` / `large4cats`, `msh/US/2/json/#`), but the
JSON it produced and consumed did not match the [Meshtastic JSON
protocol](https://meshtastic.org/docs/software/integrations/mqtt/). As shipped
in v0.2.2 the transport **cannot work against that broker**:

- every received text message is filtered out, and
- every reply it publishes is ignored by the gateway (wrong topic + wrong shape).

## What was wrong (vs. the spec)

| | Meshtastic JSON | `main` (v0.2.2) | This PR |
|---|---|---|---|
| Inbound text type | `type:"text"`, `payload:{text}` | filters `type:"sendtext"` ❌ | `type:"text"` ✅ |
| Inbound author | `from`=origin, `sender`=gateway | prefers `sender` (gateway) ❌ | prefers `from` ✅ |
| Downlink `payload` | **string** | `{ text }` ❌ | string ✅ |
| Downlink fields | `from` (num), `channel` (idx) | `sender` (str), `channel_name` ❌ | `from`, `channel` ✅ |
| Downlink topic | `…/2/json/mqtt/` | `…/mqtt` (no slash) | `…/mqtt/` ✅ |

`"sendtext"` is the **downlink** verb, so filtering inbound on it dropped all
real traffic. On uplink, `sender` is the gateway that republished to MQTT while
`from` is the actual author — preferring `sender` collapses every node in a
multi-hop mesh to the gateway (and breaks DM/allowlist matching). `sender` is a
node ID, not a display name, so it's no longer surfaced as `senderName`.

For downlinks the firmware expects `{from, type:"sendtext", payload:"<string>", channel?, to?}`
on `…/2/json/mqtt/`. The numeric `channelIndex` is now threaded through
(mirroring the serial transport's `sendText`) instead of being parsed out of the
channel name.

## Verification

No build/lint/test exists (per `AGENTS.md` the host loads TS via esbuild), so I
verified end-to-end against a **real Meshtastic gateway** + OpenClaw. Injecting a
simulated uplink and capturing the broker:

```text
↓ uplink (group text, channel index 1)
msh/RU/2/json/claw/!12345678  {"type":"text","from":305419896,"channel":1,"payload":{"text":"7×6?"}}

↑ reply downlink produced by this PR
msh/RU/2/json/mqtt/  {"from":67725112,"type":"sendtext","payload":"42","channel":1}

📡 gateway accepts it and transmits on the mesh
msh/RU/2/json/claw/!04096738  {"channel":1,"from":67725112,"payload":42,"sender":"!04096738","type":"text"}
```

Before this change the uplink was dropped and nothing was transmitted.

> **Operational note** (worth a line in the README, happy to add): for replies to
> be transmitted, the gateway needs a channel named **`mqtt`** with **downlink
> enabled** and **JSON output on**, and `mqtt.myNodeId` must be that gateway's
> node ID (used as the downlink `from`).

## Scope

Code-only, 3 files. I kept it to the protocol fix. Separately I'll open an issue
for the `openclaw/plugin-sdk/irc` + `/matrix` import paths that break loading on
current OpenClaw (2026.5.x) — that's an SDK-version concern, not a Meshtastic
one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved MQTT message routing by transitioning from channel name-based to channel index-based addressing for more reliable message delivery.
  * Updated MQTT message parsing to align with Meshtastic protocol standards for better protocol compatibility.
  * Streamlined internal message-sending APIs for consistent parameter handling across serial, HTTP, and MQTT transports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->