### PR TITLE
fix: keep URLs intact when chunking LoRa replies

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -17,6 +17,7 @@ import {
   resolveMeshtasticAccount,
   type ResolvedMeshtasticAccount,
 } from "./accounts.js";
+import { chunkText } from "./chunk.js";
 import { MeshtasticConfigSchema } from "./config-schema.js";
 import { monitorMeshtasticProvider } from "./monitor.js";
 import {
@@ -264,7 +265,7 @@ export const meshtasticPlugin: ChannelPlugin<ResolvedMeshtasticAccount, Meshtast
   },
   outbound: {
     deliveryMode: "direct",
-    chunker: (text, limit) => getMeshtasticRuntime().channel.text.chunkText(text, limit),
+    chunker: (text, limit) => chunkText(text, limit),
     chunkerMode: "text",
     textChunkLimit: 200,
     sendText: async ({ to, text, accountId }) => {

--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -1,0 +1,53 @@
+// LoRa text payload is ~230 bytes per frame. The soft limit (textChunkLimit)
+// keeps replies short; the hard limit is the most a single frame can carry.
+export const MESHTASTIC_CHUNK_LIMIT = 200;
+export const MESHTASTIC_HARD_LIMIT = 230;
+
+/**
+ * Split a reply into LoRa-sized chunks without breaking words or URLs.
+ *
+ * Reflows on whitespace, packing tokens up to `limit`. A single token longer
+ * than `limit` (typically a URL) is kept whole up to the hard frame limit so
+ * links stay valid — it's only hard-split as a last resort when it cannot fit
+ * a single frame at all. The previous implementation broke at a fixed offset
+ * when no nearby space was found, which sliced long URLs in half and produced
+ * two unusable links.
+ */
+export function chunkText(text: string, limit: number): string[] {
+  const trimmed = text.trim();
+  if (trimmed.length <= limit) {
+    return trimmed ? [trimmed] : [];
+  }
+
+  const hardMax = Math.max(limit, MESHTASTIC_HARD_LIMIT);
+
+  // Greedily pack whitespace-separated tokens, never splitting a token.
+  const packed: string[] = [];
+  let cur = "";
+  for (const word of trimmed.split(/\s+/)) {
+    if (!word) continue;
+    if (cur === "") {
+      cur = word;
+    } else if (cur.length + 1 + word.length <= limit) {
+      cur += " " + word;
+    } else {
+      packed.push(cur);
+      cur = word;
+    }
+  }
+  if (cur) packed.push(cur);
+
+  // A packed entry may still be a single token longer than the soft limit
+  // (e.g. a URL). Keep it whole if it fits one frame; otherwise hard-split.
+  const chunks: string[] = [];
+  for (const entry of packed) {
+    if (entry.length <= hardMax) {
+      chunks.push(entry);
+      continue;
+    }
+    for (let i = 0; i < entry.length; i += hardMax) {
+      chunks.push(entry.slice(i, i + hardMax));
+    }
+  }
+  return chunks;
+}

--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -1,25 +1,30 @@
 // LoRa text payload is ~230 bytes per frame. The soft limit (textChunkLimit)
-// keeps replies short; the hard limit is the most a single frame can carry.
+// keeps replies short; MESHTASTIC_HARD_LIMIT is the most a single frame can
+// carry and is enforced as an absolute ceiling.
 export const MESHTASTIC_CHUNK_LIMIT = 200;
 export const MESHTASTIC_HARD_LIMIT = 230;
 
 /**
  * Split a reply into LoRa-sized chunks without breaking words or URLs.
  *
- * Reflows on whitespace, packing tokens up to `limit`. A single token longer
- * than `limit` (typically a URL) is kept whole up to the hard frame limit so
- * links stay valid — it's only hard-split as a last resort when it cannot fit
- * a single frame at all. The previous implementation broke at a fixed offset
- * when no nearby space was found, which sliced long URLs in half and produced
- * two unusable links.
+ * Reflows on whitespace, packing tokens up to the soft limit. A single token
+ * longer than the soft limit (typically a URL) is kept whole up to the hard
+ * frame limit so links stay valid — it's only hard-split as a last resort when
+ * it cannot fit a single frame at all. The soft limit is clamped to the hard
+ * frame limit, so an over-large `textChunkLimit` can never produce a chunk that
+ * exceeds what one frame can carry.
+ *
+ * The previous implementation broke at a fixed offset when no nearby space was
+ * found, which sliced long URLs in half and produced two unusable links.
  */
 export function chunkText(text: string, limit: number): string[] {
   const trimmed = text.trim();
-  if (trimmed.length <= limit) {
+  // Clamp the soft limit to the physical frame size: callers may request a
+  // smaller (stricter) limit, but never a larger one than a frame can carry.
+  const softLimit = Math.max(1, Math.min(limit, MESHTASTIC_HARD_LIMIT));
+  if (trimmed.length <= softLimit) {
     return trimmed ? [trimmed] : [];
   }
-
-  const hardMax = Math.max(limit, MESHTASTIC_HARD_LIMIT);
 
   // Greedily pack whitespace-separated tokens, never splitting a token.
   const packed: string[] = [];
@@ -28,7 +33,7 @@ export function chunkText(text: string, limit: number): string[] {
     if (!word) continue;
     if (cur === "") {
       cur = word;
-    } else if (cur.length + 1 + word.length <= limit) {
+    } else if (cur.length + 1 + word.length <= softLimit) {
       cur += " " + word;
     } else {
       packed.push(cur);
@@ -41,12 +46,12 @@ export function chunkText(text: string, limit: number): string[] {
   // (e.g. a URL). Keep it whole if it fits one frame; otherwise hard-split.
   const chunks: string[] = [];
   for (const entry of packed) {
-    if (entry.length <= hardMax) {
+    if (entry.length <= MESHTASTIC_HARD_LIMIT) {
       chunks.push(entry);
       continue;
     }
-    for (let i = 0; i < entry.length; i += hardMax) {
-      chunks.push(entry.slice(i, i + hardMax));
+    for (let i = 0; i < entry.length; i += MESHTASTIC_HARD_LIMIT) {
+      chunks.push(entry.slice(i, i + MESHTASTIC_HARD_LIMIT));
     }
   }
   return chunks;

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -14,6 +14,7 @@ import {
 } from "openclaw/plugin-sdk/irc";
 import { createReplyPrefixOptions } from "openclaw/plugin-sdk/matrix";
 import type { ResolvedMeshtasticAccount } from "./accounts.js";
+import { chunkText, MESHTASTIC_CHUNK_LIMIT } from "./chunk.js";
 import {
   normalizeMeshtasticAllowlist,
   normalizeMeshtasticNodeId,
@@ -47,10 +48,6 @@ function resolveMeshtasticEffectiveAllowlists(params: {
   return { effectiveAllowFrom, effectiveGroupAllowFrom };
 }
 
-// LoRa payload limit is ~230 bytes.  Split longer replies into chunks
-// so the firmware doesn't silently truncate them.
-const MESHTASTIC_CHUNK_LIMIT = 200;
-
 /** Channel-level system prompt hint for LoRa-constrained responses. */
 const LORA_SYSTEM_HINT =
   "You are responding over a LoRa mesh radio (Meshtastic). " +
@@ -58,24 +55,6 @@ const LORA_SYSTEM_HINT =
   "Keep responses extremely concise — plain text only, no markdown, no emoji, no bullet lists. " +
   "Use short sentences. Omit filler words. Prioritize the most important information first.";
 
-
-function chunkText(text: string, limit: number): string[] {
-  if (text.length <= limit) return [text];
-  const chunks: string[] = [];
-  let remaining = text;
-  while (remaining.length > 0) {
-    if (remaining.length <= limit) {
-      chunks.push(remaining);
-      break;
-    }
-    // Try to break at a space near the limit.
-    let breakAt = remaining.lastIndexOf(" ", limit);
-    if (breakAt <= limit * 0.4) breakAt = limit; // no good break point
-    chunks.push(remaining.slice(0, breakAt).trimEnd());
-    remaining = remaining.slice(breakAt).trimStart();
-  }
-  return chunks;
-}
 
 async function deliverMeshtasticReply(params: {
   payload: OutboundReplyPayload;


### PR DESCRIPTION
## Problem

The reply chunker (`chunkText` in `inbound.ts`) breaks at a fixed offset when no
whitespace is found near the limit:

```ts
let breakAt = remaining.lastIndexOf(" ", limit);
if (breakAt <= limit * 0.4) breakAt = limit; // no good break point
chunks.push(remaining.slice(0, breakAt).trimEnd());
```

When a URL is longer than the chunk limit and starts early in the window, the
nearest space falls below `limit * 0.4`, so it hard-cuts at `limit` — **in the
middle of the URL**. The link arrives split across two messages and neither half
is usable. With small `textChunkLimit` values (LoRa users often set 50–90) almost
any real URL trips this.

## Fix

A word/URL-aware chunker in a new shared `src/chunk.ts`, used by **both** reply
paths (`inbound.ts` auto-reply and the `channel.ts` outbound `chunker`, which
previously diverged):

- pack whitespace-separated tokens up to the soft limit, **never splitting a token**;
- if a single token exceeds the soft limit (typically a URL), keep it **whole**
  up to the LoRa frame limit (`MESHTASTIC_HARD_LIMIT`), so the link stays valid;
- hard-split only as a last resort, when a token can't fit one frame at all.

URLs are ASCII, so keeping one up to ~230 chars whole still fits a single LoRa
text frame.

## Verification

No build/test harness exists (host loads TS via esbuild), so:

**Unit** (offline, against the real `chunk.ts`):
```
✓ short text = one chunk
✓ no chunk contains a TRUNCATED URL (every https:// chunk has the full URL)
✓ all chunks within hard frame limit (230)
✓ URL longer than a frame is split (unavoidable)
✓ ordinary chunks within soft limit; all words preserved, none split
✓ regression case: early-space + long URL kept whole
```

**Live**, over a real Meshtastic gateway + agent. A reply with a 92-char URL,
soft limit 90:
```text
"Документация по модулю MQTT:"
"https://meshtastic.org/docs/configuration/module/mqtt/?some=query&more=stuff&extra=1234567890"
"читай перед настройкой шлюза."
```
The URL arrives **whole** on its own chunk. Before this change it was cut
mid-link into two dead halves.

## Scope

`src/chunk.ts` (new) + `inbound.ts` (drop the local chunker, import the shared one)
+ `channel.ts` (point the outbound `chunker` at it). Independent of #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated message chunking logic to improve consistency and reliability when splitting and sending long messages, reducing chances of broken or unevenly sized message parts across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->